### PR TITLE
Bump dompurify from 3.2.1 to 3.2.4 in the npm_and_yarn group

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2495,9 +2495,9 @@
 			"license": "MIT"
 		},
 		"node_modules/dompurify": {
-			"version": "3.2.1",
-			"resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.1.tgz",
-			"integrity": "sha512-NBHEsc0/kzRYQd+AY6HR6B/IgsqzBABrqJbpCDQII/OK6h7B7LXzweZTDsqSW2LkTRpoxf18YUP+YjGySk6B3w==",
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.4.tgz",
+			"integrity": "sha512-ysFSFEDVduQpyhzAob/kkuJjf5zWkZD8/A9ywSp1byueyuCfHamrCBa14/Oc2iiB0e51B+NpxSl5gmzn+Ms/mg==",
 			"license": "(MPL-2.0 OR Apache-2.0)",
 			"optionalDependencies": {
 				"@types/trusted-types": "^2.0.7"


### PR DESCRIPTION
Bumps the npm_and_yarn group with 1 update: [dompurify](https://github.com/cure53/DOMPurify).


Updates `dompurify` from 3.2.1 to 3.2.4
- [Release notes](https://github.com/cure53/DOMPurify/releases)
- [Commits](https://github.com/cure53/DOMPurify/compare/3.2.1...3.2.4)

---
updated-dependencies:
- dependency-name: dompurify dependency-type: indirect dependency-group: npm_and_yarn ...