### PR TITLE
2 change default draggable behavior

### DIFF
--- a/src/lib/components/cytoscape/Cytoscape.svelte
+++ b/src/lib/components/cytoscape/Cytoscape.svelte
@@ -91,7 +91,8 @@
         myTip?.destroy();
         myTip = newTip;
     }
-    var loadGraph = async () => {
+
+    const loadGraph = async () => {
 
         progress = {
             text: "Fetching Graph Data...",
@@ -103,7 +104,7 @@
         courseData.forEach((item: any) => {
             item['pannable'] = true;
         });
-        
+
         progress = {
             text: "Styling Graph...",
             number: 50,
@@ -112,7 +113,7 @@
         let styleResponse = await fetch(styleUrl);
         let styleData: StyleData[] = await styleResponse.json();
 
-        let cytoscapeStyles : Stylesheet[] = [
+        let cytoscapeStyles: Stylesheet[] = [
             {
                 selector: 'node',
                 style: {
@@ -169,9 +170,9 @@
             },
             {
                 selector: '.highlighted-edges',
-                    style: {
-                        'width': 2,
-                    }
+                style: {
+                    'width': 2,
+                }
             },
             {
                 selector: '.no-overlay',
@@ -301,10 +302,11 @@
                 $selectedCourse = null;
                 $sheetOpen = true;
 
-                fetchCourse(targetNode.id()).then(() => {});
+                fetchCourse(targetNode.id()).then(() => {
+                });
                 return;
             }
-            
+
             let tip = targetNode.popper({
                 content: () => {
                     let div = document.createElement('div');
@@ -359,7 +361,7 @@
         }
 
 
-    }
+    };
     onMount(() => loadGraph())
 
 </script>

--- a/src/lib/components/cytoscape/Cytoscape.svelte
+++ b/src/lib/components/cytoscape/Cytoscape.svelte
@@ -55,17 +55,7 @@
 
     let elementsAreDraggable = true;
     const toggleDraggableElements = () => {
-        if (elementsAreDraggable) {
-            cy.nodes().forEach((node) => {
-                node.ungrabify();
-            });
-            elementsAreDraggable = false;
-        } else {
-            cy.nodes().forEach((node) => {
-                node.grabify();
-            });
-            elementsAreDraggable = true;
-        }
+        elementsAreDraggable = !elementsAreDraggable;
     }
 
     const isDesktop = () => window.matchMedia('(min-width: 768px)').matches;
@@ -276,13 +266,17 @@
         cy.on('mouseover', 'node', function (event) {
             const targetNode = event.target;
             highlightPath(targetNode);
+            if (elementsAreDraggable) {
+                targetNode.grabify();
+            } else {
+                targetNode.ungrabify();
+            }
         });
 
         cy.on('mouseout', 'node', function (event) {
             cy.nodes().removeClass('highlighted-nodes');
             cy.elements().removeClass('faded');
             cy.edges().removeClass('highlighted-edges');
-
             myTip?.destroy();
         });
 
@@ -299,7 +293,7 @@
                 fetchCourse(targetNode.id()).then(() => {});
                 return;
             }
-
+            
             let tip = targetNode.popper({
                 content: () => {
                     let div = document.createElement('div');

--- a/src/lib/components/cytoscape/Cytoscape.svelte
+++ b/src/lib/components/cytoscape/Cytoscape.svelte
@@ -53,7 +53,7 @@
         cy.zoom(cy.zoom() - 0.1);
     };
 
-    let elementsAreDraggable = true;
+    let elementsAreDraggable = false;
     const toggleDraggableElements = () => {
         elementsAreDraggable = !elementsAreDraggable;
     }
@@ -101,7 +101,10 @@
 
         let response = await fetch(url);
         let courseData = await response.json();
-
+        courseData.forEach((item: any) => {
+            item['grabbable'] = false;
+        });
+        
         progress = {
             text: "Styling Graph...",
             number: 50,

--- a/src/lib/components/cytoscape/Cytoscape.svelte
+++ b/src/lib/components/cytoscape/Cytoscape.svelte
@@ -91,8 +91,7 @@
         myTip?.destroy();
         myTip = newTip;
     }
-
-    onMount(async () => {
+    var loadGraph = async () => {
 
         progress = {
             text: "Fetching Graph Data...",
@@ -102,7 +101,7 @@
         let response = await fetch(url);
         let courseData = await response.json();
         courseData.forEach((item: any) => {
-            item['grabbable'] = false;
+            item['pannable'] = false;
         });
         
         progress = {
@@ -173,6 +172,13 @@
                     style: {
                         'width': 2,
                     }
+            },
+            {
+                selector: '.no-underlay',
+                style: {
+                    'overlay-padding': 0,
+                    'overlay-opacity': 0,
+                }
             }
         ]
 
@@ -270,9 +276,11 @@
             const targetNode = event.target;
             highlightPath(targetNode);
             if (elementsAreDraggable) {
-                targetNode.grabify();
+                targetNode.removeClass('no-underlay');
+                targetNode.unpanify();
             } else {
-                targetNode.ungrabify();
+                targetNode.addClass('no-underlay');
+                targetNode.panify();
             }
         });
 
@@ -351,7 +359,8 @@
         }
 
 
-    })
+    }
+    onMount(() => loadGraph())
 
 </script>
 <div class="relative grow" id="cy-container">

--- a/src/lib/components/cytoscape/Cytoscape.svelte
+++ b/src/lib/components/cytoscape/Cytoscape.svelte
@@ -5,7 +5,13 @@
     import tippy from "tippy.js";
     import cytoscapePopper from "cytoscape-popper";
     import {Button} from "$lib/components/ui/button";
-    import {LucideFullscreen, LucideHand, LucideMail, LucideMinus, LucideMousePointer, LucidePlus} from "lucide-svelte";
+    import {
+        LockKeyhole,
+        LockKeyholeOpen,
+        LucideFullscreen,
+        LucideMinus,
+        LucidePlus
+    } from "lucide-svelte";
     import {Progress} from "$lib/components/ui/progress";
     import {cn} from "$lib/utils.ts";
     import {type Course, courseReferenceToString, sanitizeCourseToReferenceString} from "$lib/types/course.ts";
@@ -19,6 +25,7 @@
     import {ScrollArea} from "$lib/components/ui/scroll-area";
     import InstructorPreview from "$lib/components/instructor-preview/InstructorPreview.svelte";
     import {apiFetch} from "$lib/api.ts";
+    import {Tooltip, TooltipContent, TooltipProvider, TooltipTrigger} from "../ui/tooltip";
 
     export let url: string
     export let styleUrl: string
@@ -372,13 +379,27 @@
     </div> <div id="cy" class={cn("w-full h-full transition-opacity", progress.number !== 100 ? "opacity-0" : "")}></div>
 
     <div class="absolute bottom-4 right-4 flex flex-col space-y-2">
-        <Button size="sm" variant="outline" class="h-8 w-8 px-0" onclick={toggleDraggableElements}>
-            {#if elementsAreDraggable}
-                <LucideHand class="h-5 w-5" />
-            {:else}
-                <LucideMousePointer class="h-5 w-5"/>
-            {/if}
-        </Button>
+        <TooltipProvider>
+            <Tooltip>
+                <TooltipTrigger>
+                    <Button size="sm" variant="outline" class="h-8 w-8 px-0" onclick={toggleDraggableElements}>
+                        {#if elementsAreDraggable}
+                            <LockKeyholeOpen class="h-5 w-5" />
+                        {:else}
+                            <LockKeyhole class="h-5 w-5"/>
+                        {/if}
+                    </Button>
+                </TooltipTrigger>
+                <TooltipContent>
+                    {#if elementsAreDraggable}
+                        Lock Elements
+                    {:else}
+                        Unlock Elements
+                    {/if}
+                </TooltipContent>
+            </Tooltip>
+        </TooltipProvider>
+
         <Button size="sm" variant="outline" class="h-8 w-8 px-0" onclick={zoomIn}>
             <LucidePlus class="h-5 w-5"/>
         </Button>

--- a/src/lib/components/cytoscape/Cytoscape.svelte
+++ b/src/lib/components/cytoscape/Cytoscape.svelte
@@ -447,7 +447,15 @@
                         <div class="font-semibold mt-2">INSTRUCTORS</div>
                         <Separator class="my-1" />
                     {/if}
-                    <InstructorPreview instructor={{name: name, email: email, data: null}}/>
+                    <InstructorPreview instructor={{
+                        name: name,
+                        email: email,
+                        credentials: null,
+                        rmp_data: null,
+                        department: null,
+                        official_name: null,
+                        position: null
+                    }}/>
                 {/each}
             {/if}
         </ScrollArea>

--- a/src/lib/components/cytoscape/Cytoscape.svelte
+++ b/src/lib/components/cytoscape/Cytoscape.svelte
@@ -5,7 +5,7 @@
     import tippy from "tippy.js";
     import cytoscapePopper from "cytoscape-popper";
     import {Button} from "$lib/components/ui/button";
-    import {LucideFullscreen, LucideMail, LucideMinus, LucidePlus} from "lucide-svelte";
+    import {LucideFullscreen, LucideHand, LucideMail, LucideMinus, LucideMousePointer, LucidePlus} from "lucide-svelte";
     import {Progress} from "$lib/components/ui/progress";
     import {cn} from "$lib/utils.ts";
     import {type Course, courseReferenceToString, sanitizeCourseToReferenceString} from "$lib/types/course.ts";
@@ -52,6 +52,21 @@
     const zoomOut = () => {
         cy.zoom(cy.zoom() - 0.1);
     };
+
+    let elementsAreDraggable = true;
+    const toggleDraggableElements = () => {
+        if (elementsAreDraggable) {
+            cy.nodes().forEach((node) => {
+                node.ungrabify();
+            });
+            elementsAreDraggable = false;
+        } else {
+            cy.nodes().forEach((node) => {
+                node.grabify();
+            });
+            elementsAreDraggable = true;
+        }
+    }
 
     const isDesktop = () => window.matchMedia('(min-width: 768px)').matches;
 
@@ -349,10 +364,16 @@
     </div> <div id="cy" class={cn("w-full h-full transition-opacity", progress.number !== 100 ? "opacity-0" : "")}></div>
 
     <div class="absolute bottom-4 right-4 flex flex-col space-y-2">
+        <Button size="sm" variant="outline" class="h-8 w-8 px-0" onclick={toggleDraggableElements}>
+            {#if elementsAreDraggable}
+                <LucideHand class="h-5 w-5" />
+            {:else}
+                <LucideMousePointer class="h-5 w-5"/>
+            {/if}
+        </Button>
         <Button size="sm" variant="outline" class="h-8 w-8 px-0" onclick={zoomIn}>
             <LucidePlus class="h-5 w-5"/>
         </Button>
-
         <!-- Zoom Out Button -->
         <Button  size="sm" variant="outline" class="h-8 w-8 px-0" onclick={zoomOut}>
             <LucideMinus class="h-5 w-5"/>

--- a/src/lib/components/cytoscape/Cytoscape.svelte
+++ b/src/lib/components/cytoscape/Cytoscape.svelte
@@ -101,7 +101,7 @@
         let response = await fetch(url);
         let courseData = await response.json();
         courseData.forEach((item: any) => {
-            item['pannable'] = false;
+            item['pannable'] = true;
         });
         
         progress = {
@@ -174,7 +174,7 @@
                     }
             },
             {
-                selector: '.no-underlay',
+                selector: '.no-overlay',
                 style: {
                     'overlay-padding': 0,
                     'overlay-opacity': 0,
@@ -274,14 +274,14 @@
 
         cy.on('mouseover', 'node', function (event) {
             const targetNode = event.target;
-            highlightPath(targetNode);
             if (elementsAreDraggable) {
-                targetNode.removeClass('no-underlay');
+                targetNode.removeClass('no-overlay');
                 targetNode.unpanify();
             } else {
-                targetNode.addClass('no-underlay');
+                targetNode.addClass('no-overlay');
                 targetNode.panify();
             }
+            highlightPath(targetNode);
         });
 
         cy.on('mouseout', 'node', function (event) {


### PR DESCRIPTION
I was also trying to add two other features (I wouldn't prioritize these as they aren't absolutely necessary to have):
1. The cursor turns into a grab icon
2. When a node is undraggable and the user tries to drag it, the black overlay would not appear.

For 1, according to [stackoverflow](https://stackoverflow.com/questions/19532031/how-do-i-change-cursor-to-pointer-when-mouse-is-over-a-node) cy does not support pointer css. 