### PR TITLE
Add Text Outline in Course Graph

### DIFF
--- a/src/lib/components/cytoscape/cytoscape.svelte
+++ b/src/lib/components/cytoscape/cytoscape.svelte
@@ -20,7 +20,7 @@
     import {generateFcoseLayout, generateLayeredLayout, LayoutType} from "$lib/components/cytoscape/graph-layout.ts";
     import {page} from "$app/state";
     import {mode} from "mode-watcher";
-    import {getTextColor} from "$lib/theme.ts";
+    import {getCarbonTheme, getTextColor} from "$lib/theme.ts";
     import Legend from "./legend.svelte";
 
     interface Props {
@@ -86,7 +86,7 @@
             text: "Fetching Graph Data...",
             number: 25,
         }
-        
+
         courseData = await fetchGraphData(url);
 
         progress = {
@@ -120,7 +120,7 @@
         // if you want to use the other layout, just uncomment the one below and comment the other one
         // let newCytoscapeLayout = await generateLayeredLayout(courseData);
         let layout = await computeLayout(layoutType);
-        
+
         progress = {
             text: "Graph Loaded",
             number: 99,
@@ -219,6 +219,7 @@
         }
         cy.style().selector('node').style({
             'color': getTextColor($mode),
+            'text-outline-color': getCarbonTheme($mode),
 	        'text-outline-opacity': 1,
 	        'text-outline-width': 2
         }).selector('.highlighted-nodes').style({

--- a/src/lib/components/cytoscape/cytoscape.svelte
+++ b/src/lib/components/cytoscape/cytoscape.svelte
@@ -20,7 +20,7 @@
     import {generateFcoseLayout, generateLayeredLayout, LayoutType} from "$lib/components/cytoscape/graph-layout.ts";
     import {page} from "$app/state";
     import {mode} from "mode-watcher";
-    import {getCarbonTheme, getTextColor} from "$lib/theme.ts";
+    import {getTextColor, getTextOutlineColor} from "$lib/theme.ts";
     import Legend from "./legend.svelte";
 
     interface Props {
@@ -219,7 +219,7 @@
         }
         cy.style().selector('node').style({
             'color': getTextColor($mode),
-            'text-outline-color': getCarbonTheme($mode),
+            'text-outline-color': getTextOutlineColor($mode),
 	        'text-outline-opacity': 1,
 	        'text-outline-width': 2
         }).selector('.highlighted-nodes').style({

--- a/src/lib/components/cytoscape/cytoscape.svelte
+++ b/src/lib/components/cytoscape/cytoscape.svelte
@@ -218,7 +218,9 @@
             return;
         }
         cy.style().selector('node').style({
-            'color': getTextColor($mode)
+            'color': getTextColor($mode),
+	        'text-outline-opacity': 1,
+	        'text-outline-width': 2,
         }).selector('.highlighted-nodes').style({
             'border-color': getTextColor($mode),
         }).selector('edge').style({

--- a/src/lib/components/cytoscape/cytoscape.svelte
+++ b/src/lib/components/cytoscape/cytoscape.svelte
@@ -220,7 +220,7 @@
         cy.style().selector('node').style({
             'color': getTextColor($mode),
 	        'text-outline-opacity': 1,
-	        'text-outline-width': 2,
+	        'text-outline-width': 2
         }).selector('.highlighted-nodes').style({
             'border-color': getTextColor($mode),
         }).selector('edge').style({

--- a/src/lib/theme.ts
+++ b/src/lib/theme.ts
@@ -1,5 +1,4 @@
 export function getCarbonTheme(mode: "light" | "dark" | undefined) {
-
     switch (mode) {
         case "light":
             return "white"
@@ -19,5 +18,16 @@ export function getTextColor(mode: "light" | "dark" | undefined) {
             return "white"
         default:
             return "black"
+    }
+}
+
+export function getTextOutlineColor(mode: "light" | "dark" | undefined) {
+    switch (mode) {
+        case "light":
+            return "white"
+        case "dark":
+            return "black"
+        default:
+            return "white"
     }
 }

--- a/src/lib/theme.ts
+++ b/src/lib/theme.ts
@@ -1,4 +1,5 @@
 export function getCarbonTheme(mode: "light" | "dark" | undefined) {
+
     switch (mode) {
         case "light":
             return "white"


### PR DESCRIPTION
Outlines the text of nodes in the course graph so that it can be better read over the graph edges (arrows).