### PR TITLE
399 uploading transcript debug and regex bug

### DIFF
--- a/src/routes/upload/+page.svelte
+++ b/src/routes/upload/+page.svelte
@@ -69,7 +69,7 @@
             }
             
             //get course subject and numbers
-            const regex = /(\b[A-Z]+(?:\s[A-Z]+)*\b)\s+(X\d{2}|\d{3})/g;
+            const regex = /(\b[A-Z&]+(?:\s[A-Z&]+)*\b)\s+(X\d{2}|\d{3})/g;
             let matches, results = [];
             
             while ((matches = regex.exec(text)) !== null) {


### PR DESCRIPTION
added better debug for the user and devs for when parsing courses fails. 

Fixed parse bug - was because of the special character "&" not being included in search so MS&E wasn't found correctly