### PR TITLE
Fix exclusion compatibly drop branches with not

### DIFF
--- a/generation/embeddings.py
+++ b/generation/embeddings.py
@@ -182,7 +182,7 @@ def prune_prerequisites(
             logger=logger
         )
 
-        course.optimized_prerequisites = [c.course_reference for c in best],
+        course.optimized_prerequisites = [c.course_reference for c in best]
 
 def optimize_prerequisite(
         cache_dir,

--- a/generation/embeddings.py
+++ b/generation/embeddings.py
@@ -182,7 +182,7 @@ def prune_prerequisites(
             logger=logger
         )
 
-        course.optimized_prerequisites = best
+        course.optimized_prerequisites = [c.course_reference for c in best],
 
 def optimize_prerequisite(
         cache_dir,


### PR DESCRIPTION
Proper exclusion allowed for fallback case to complete, resulting in an improper assignment of the optimized_prerequisites attribute