### PR TITLE
Add Interactive Count/Percentage Toggle to Grade Distribution Chart

### DIFF
--- a/src/lib/components/charts/grade-data-horizontal-bar-chart.svelte
+++ b/src/lib/components/charts/grade-data-horizontal-bar-chart.svelte
@@ -10,6 +10,7 @@
   import { getCarbonTheme } from "$lib/theme.ts";
   import { mode } from "mode-watcher";
   import type { TermData } from "$lib/types/course.ts";
+  import { Button } from "$lib/components/ui/button/index.js";
 
   interface Props {
     cumulative: GradeData;
@@ -21,46 +22,60 @@
 
   let { cumulative, termData, term = null }: Props = $props();
 
+  // Toggle state for percentage/count view
+  let showPercentages = $state(true);
+  
   let gradeData = $derived(
     term ? (termData[term].grade_data ?? cumulative) : cumulative,
   );
+
+  // Calculate raw data
+  let rawData = $derived([
+    {
+      group: "A",
+      value: gradeData.a,
+    },
+    {
+      group: "AB",
+      value: gradeData.ab,
+    },
+    {
+      group: "B",
+      value: gradeData.b,
+    },
+    {
+      group: "BC",
+      value: gradeData.bc,
+    },
+    {
+      group: "C",
+      value: gradeData.c,
+    },
+    {
+      group: "D",
+      value: gradeData.d,
+    },
+    {
+      group: "F",
+      value: gradeData.f,
+    },
+    {
+      group: "Other",
+      value: getTotalOtherGrades(gradeData),
+    },
+  ]);
+
+  // Dynamic data processing for percentage/count toggle
   let data: ChartTabularData = $derived(
-    [
-      {
-        group: "A",
-        value: gradeData.a,
-      },
-      {
-        group: "AB",
-        value: gradeData.ab,
-      },
-      {
-        group: "B",
-        value: gradeData.b,
-      },
-      {
-        group: "BC",
-        value: gradeData.bc,
-      },
-      {
-        group: "C",
-        value: gradeData.c,
-      },
-      {
-        group: "D",
-        value: gradeData.d,
-      },
-      {
-        group: "F",
-        value: gradeData.f,
-      },
-      {
-        group: "Other",
-        value: getTotalOtherGrades(gradeData),
-      },
-    ].reverse(),
+    showPercentages && gradeData.total > 0
+      ? rawData.map(item => ({
+          ...item,
+          value: Number(((item.value / gradeData.total) * 100).toFixed(1))
+        })).reverse()
+      : rawData.slice().reverse()
   );
 
+  // Enhanced chart options with dynamic configuration
   let options: BarChartOptions = $derived({
     title: "Grade Distribution",
     axes: {
@@ -70,6 +85,7 @@
       },
       bottom: {
         mapsTo: "value",
+        title: showPercentages ? "Percentage" : "Count"
       },
     },
     legend: {
@@ -78,10 +94,58 @@
     toolbar: {
       enabled: false,
     },
+    // Disable animations to prevent numbers sliding when switching views
+    animations: false,
+    // Custom tooltip implementation
+    tooltip: {
+      valueFormatter: (value: number) => showPercentages ? `${value}%` : value.toString(),
+      customHTML: (data: any) => {
+        const dataPoint = data[0];
+        const displayValue = showPercentages 
+          ? `${dataPoint.value}%` 
+          : `${dataPoint.value}/${gradeData.total}`;
+        return `
+          <div class="bg-background border border-border rounded p-2 shadow-md">
+            <div class="text-sm">
+              <span class="font-medium">${dataPoint.group}</span>: ${displayValue}
+            </div>
+          </div>
+        `;
+      }
+    },
     theme: getCarbonTheme(mode.current),
   });
+
+  // Button click handlers
+  function setPercentageView() {
+    showPercentages = true;
+  }
+
+  function setCountView() {
+    showPercentages = false;
+  }
 </script>
 
-<div class="h-full">
+<div class="h-full relative">
+  <!-- Count/Percentage Toggle Buttons -->
+  <div class="absolute top-2 right-2 z-10 flex rounded-md border border-border bg-background/95 backdrop-blur-sm shadow-sm">
+    <Button
+      onclick={setCountView}
+      variant={!showPercentages ? "default" : "ghost"}
+      size="sm"
+      class="rounded-r-none border-r border-border/50 text-xs px-3 py-1 h-7"
+    >
+      Count
+    </Button>
+    <Button
+      onclick={setPercentageView}
+      variant={showPercentages ? "default" : "ghost"}
+      size="sm"
+      class="rounded-l-none text-xs px-3 py-1 h-7"
+    >
+      Percentage
+    </Button>
+  </div>
+  
   <BarChartSimple {data} {options} />
 </div>


### PR DESCRIPTION

This update improves the grade distribution chart by adding a toggle to switch between raw counts and percentages, using Svelte 5’s new reactive state features.

---

## Summary

Closes: [#801](https://github.com/twangodev/uw-coursemap/issues/801)

This PR adds a user-friendly toggle to the grade distribution chart so users can view data as either raw counts or percentages. It enhances clarity, flexibility, and accessibility.

---

## What’s New

### Toggle Between Count and Percentage
- Two-button toggle (Count | Percentage)
- Default is **Percentage** for better comparison across courses
- State managed using Svelte 5’s `$state` and `$derived` runes

---

## File Modified

- `src/lib/components/charts/grade-data-horizontal-bar-chart.svelte`

---

## Screenshots / Demo

<img width="582" alt="Screenshot 2025-06-12 at 11 31 47" src="https://github.com/user-attachments/assets/dd8ee733-83bd-47f9-8540-386aeb224d07" />

<img width="584" alt="Screenshot 2025-06-12 at 11 32 06" src="https://github.com/user-attachments/assets/2557cbb8-7d05-44dc-9e37-2488c85ee6ef" />

<img width="578" alt="Screenshot 2025-06-12 at 11 32 19" src="https://github.com/user-attachments/assets/ef13e30d-0c3a-427a-bf5c-d2172a678afd" />

<img width="584" alt="Screenshot 2025-06-12 at 11 32 38" src="https://github.com/user-attachments/assets/d208cbdc-1bef-40fc-bc68-740a212b56b8" />

