### PR TITLE
Fixed Aggregate.py 

### DIFF
--- a/generation/aggregate.py
+++ b/generation/aggregate.py
@@ -350,7 +350,7 @@ def aggregate_instructors(
                     term_data.grade_data
                 )
 
-                instructor.courses_taught.add(course_reference.get_identifier())
+                instructor.courses_taught.add(course_reference)
                 instructor.cumulative_grade_data = grade_data_summation
 
     instructor_statistics = {


### PR DESCRIPTION
It now to use course references instead of string references in aggregate_instructors method

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal data structure handling for instructor course information to enhance type consistency and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->